### PR TITLE
cTCPLink: Use the original connection hostname for SNI.

### DIFF
--- a/src/Bindings/LuaTCPLink.cpp
+++ b/src/Bindings/LuaTCPLink.cpp
@@ -193,8 +193,7 @@ AString cLuaTCPLink::StartTLSClient(
 			}
 		}
 
-		// TODO : Provide a way to pass SNI from Lua too.
-		return link->StartTLSClient(ownCert, ownPrivKey, "");
+		return link->StartTLSClient(ownCert, ownPrivKey);
 	}
 	return "";
 }

--- a/src/HTTP/UrlClient.cpp
+++ b/src/HTTP/UrlClient.cpp
@@ -299,7 +299,7 @@ public:
 		m_Link = &a_Link;
 		if (m_IsTls)
 		{
-			m_Link->StartTLSClient(m_ParentRequest.GetOwnCert(), m_ParentRequest.GetOwnPrivKey(), m_ParentRequest.m_UrlHost);
+			m_Link->StartTLSClient(m_ParentRequest.GetOwnCert(), m_ParentRequest.GetOwnPrivKey());
 		}
 		else
 		{

--- a/src/OSSupport/Network.h
+++ b/src/OSSupport/Network.h
@@ -113,8 +113,7 @@ public:
 	Returns empty string on success, non-empty error description on failure. */
 	virtual AString StartTLSClient(
 		cX509CertPtr a_OwnCert,
-		cCryptoKeyPtr a_OwnPrivKey,
-		const std::string_view hostname
+		cCryptoKeyPtr a_OwnPrivKey
 	) = 0;
 
 	/** Starts a TLS handshake as a server connection.

--- a/src/OSSupport/TCPLinkImpl.h
+++ b/src/OSSupport/TCPLinkImpl.h
@@ -40,9 +40,16 @@ public:
 
 	/** Creates a new link based on the given socket.
 	Used for connections accepted in a server using cNetwork::Listen().
+	a_Host is the hostname used for TLS SNI (can be empty in cases TLS is not used).
 	a_Address and a_AddrLen describe the remote peer that has connected.
 	The link is created disabled, you need to call Enable() to start the regular communication. */
-	cTCPLinkImpl(evutil_socket_t a_Socket, cCallbacksPtr a_LinkCallbacks, cServerHandleImplPtr a_Server, const sockaddr * a_Address, socklen_t a_AddrLen);
+	cTCPLinkImpl(
+		evutil_socket_t a_Socket,
+		cCallbacksPtr a_LinkCallbacks,
+		cServerHandleImplPtr a_Server,
+		const sockaddr * a_Address,
+		socklen_t a_AddrLen
+	);
 
 	/** Destroys the LibEvent handle representing the link. */
 	virtual ~cTCPLinkImpl() override;
@@ -68,8 +75,7 @@ public:
 	virtual void Close(void) override;
 	virtual AString StartTLSClient(
 		cX509CertPtr a_OwnCert,
-		cCryptoKeyPtr a_OwnPrivKey,
-		const std::string_view hostname
+		cCryptoKeyPtr a_OwnPrivKey
 	) override;
 	virtual AString StartTLSServer(
 		cX509CertPtr a_OwnCert,
@@ -151,6 +157,10 @@ protected:
 	/** The port of the local endpoint. Valid only after the socket has been connected. */
 	UInt16 m_LocalPort;
 
+	/** The original host parameter which was used for creating the link, either hostname or IP address.
+	Used for TLS SNI. */
+	AString m_RemoteHost;
+
 	/** The IP address of the remote endpoint. Valid only after the socket has been connected. */
 	AString m_RemoteIP;
 
@@ -175,7 +185,7 @@ protected:
 	Used for outgoing connections created using cNetwork::Connect().
 	To be used only by the Connect() factory function.
 	The link is created disabled, you need to call Enable() to start the regular communication. */
-	cTCPLinkImpl(const cCallbacksPtr a_LinkCallbacks);
+	cTCPLinkImpl(const std::string & a_Host, const cCallbacksPtr a_LinkCallbacks);
 
 	/** Callback that LibEvent calls when there's data available from the remote peer. */
 	static void ReadCallback(bufferevent * a_BufferEvent, void * a_Self);

--- a/src/mbedTLS++/SslContext.h
+++ b/src/mbedTLS++/SslContext.h
@@ -51,7 +51,9 @@ public:
 	/** Returns true if the object has been initialized properly. */
 	bool IsValid(void) const { return m_IsValid; }
 
-	/** Sets the SSL peer name expected for this context. Must be called after Initialize().
+	/** Sets the SSL peer name expected for this context.
+	This is used both for TLS SNI and for certificate validation.
+	Must be called after Initialize().
 	\param a_ExpectedPeerName CommonName that we expect the SSL peer to have in its cert,
 	if it is different, the verification will fail. An empty string will disable the CN check. */
 	void SetExpectedPeerName(const std::string_view a_ExpectedPeerName);


### PR DESCRIPTION
This changes the `cTCPLink` implementation to use the hostname provided in the `Connect` call for SNI, rather than a separate parameter.